### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "pygame"
+run = ""

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 Free Python Games
 =================
-
+[![Run on Repl.it](https://repl.it/badge/github/grantjenks/free-python-games)](https://repl.it/github/grantjenks/free-python-games)
 `Free Python Games`_ is an Apache2 licensed collection of free Python games
 intended for education and fun. The games are written in simple Python code and
 designed for experimentation and changes. Simplified versions of several


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@reza02/free-python-games).