### PR TITLE
Printing value beforehand

### DIFF
--- a/freegames/guess.py
+++ b/freegames/guess.py
@@ -14,7 +14,7 @@ start = 1
 end = 100
 value = randint(start, end)
 
-print(value)
+# print(value)
 print("I'm thinking of a number between", start, 'and', end)
 
 guess = None


### PR DESCRIPTION
Printing the number before the user can actually guess the number. Doesn't justify the game, so need to comment the line. Already raised an [issue](https://github.com/grantjenks/free-python-games/issues/83) regarding this. So, this CR is raised corresponding to that.

![image](https://user-images.githubusercontent.com/40369168/164971862-a044423d-1627-48b3-8d55-3e72c5f603e2.png)
