### PR TITLE
Prevent turtle.Terminator error when closing game window

### DIFF
--- a/src/freegames/life.py
+++ b/src/freegames/life.py
@@ -52,13 +52,16 @@ def step():
 
 def draw():
     """Draw all the squares."""
-    step()
-    clear()
-    for (x, y), alive in cells.items():
-        color = 'green' if alive else 'black'
-        square(x, y, 10, color)
-    update()
-    ontimer(draw, 100)
+    try:
+        step()
+        clear()
+        for (x, y), alive in cells.items():
+            color = 'green' if alive else 'black'
+            square(x, y, 10, color)
+        update()
+        ontimer(draw, 100)
+    except Terminator:
+        print("Window closed. Stopping update.")
 
 
 setup(420, 420, 370, 0)


### PR DESCRIPTION
Added `try...except Terminator` inside `draw()`Prevent turtle.Terminator error when closing game window. 

Related issue: #98

Also, I believe applying the same method to other games would be beneficial.